### PR TITLE
Update Jamfile.v2

### DIFF
--- a/doc/Jamfile.v2
+++ b/doc/Jamfile.v2
@@ -4,7 +4,7 @@
 #   (See accompanying file LICENSE_1_0.txt or copy at
 #   http://www.boost.org/LICENSE_1_0.txt)
 
-project boost/doc ;
+project boostbook/doc ;
 import boostbook : boostbook ;
 
 boostbook boostbook : boostbook.xml :


### PR DESCRIPTION
There can be only one project named boost/doc and we have that already under /doc/
Change to something unique.
Fixes PDF doc build.
