### PR TITLE
Update fo.xsl

### DIFF
--- a/xsl/fo.xsl
+++ b/xsl/fo.xsl
@@ -216,7 +216,7 @@
       </xsl:choose>
     </fo:list-item-label>
     <fo:list-item-body start-indent="body-start()">
-      <xsl:apply-templates select="*[local-name(.)!='label']"/>text-align
+      <xsl:apply-templates select="*[local-name(.)!='label']"/>
     </fo:list-item-body>
   </fo:list-item>
 </xsl:template>


### PR DESCRIPTION
Remove stray text on end of line.
Fixes PDF doc build.
Aside: this whole Q&A set block could probably be removed now given that it appears to be a workaround for the ancient FOP-0.2.
