### PR TITLE
Make copyright footer generation simpler and more flexible.

### DIFF
--- a/xsl/html-base.xsl
+++ b/xsl/html-base.xsl
@@ -219,53 +219,13 @@ set       toc,title
   </xsl:template>
 
   <xsl:template name="user.footer.content">
-    <table width="100%">
-      <tr>
-        <td align="left">
-          <xsl:variable name="revision-nodes"
-            select="ancestor-or-self::*
-                    [not (attribute::rev:last-revision='')]"/>
-          <xsl:if test="count($revision-nodes) &gt; 0">
-            <xsl:variable name="revision-node"
-              select="$revision-nodes[last()]"/>
-            <xsl:variable name="revision-text">
-              <xsl:value-of
-                select="normalize-space($revision-node/attribute::rev:last-revision)"/>
-            </xsl:variable>
-            <xsl:if test="string-length($revision-text) &gt; 0 and not($revision-text = '$Date$')">
-              <p>
-                <small>
-                  <xsl:text>Last revised: </xsl:text>
-                  <xsl:choose>
-                    <xsl:when test="not(contains($revision-text, '$Date: ')) and not(contains($revision-text, '$Date:: '))">
-                      <xsl:value-of select="$revision-text"/>
-                    </xsl:when>
-                    <xsl:when test="contains($revision-text, '/')">
-                      <xsl:call-template name="format.cvs.revision">
-                        <xsl:with-param name="text" select="$revision-text"/>
-                      </xsl:call-template>
-                    </xsl:when>
-                    <xsl:otherwise>
-                      <xsl:call-template name="format.svn.revision">
-                        <xsl:with-param name="text" select="$revision-text"/>
-                      </xsl:call-template>
-                    </xsl:otherwise>
-                  </xsl:choose>
-                </small>
-              </p>
-            </xsl:if>
-          </xsl:if>
-        </td>
-        <td align="right">
-          <div class = "copyright-footer">
-            <xsl:apply-templates select="ancestor::*/*/copyright"
-              mode="boost.footer"/>
-            <xsl:apply-templates select="ancestor::*/*/legalnotice"
-              mode="boost.footer"/>
-          </div>
-        </td>
-      </tr>
-    </table>
+    <div class = "copyright-footer">
+      <xsl:apply-templates select="ancestor::*/*/copyright"
+                           mode="boost.footer"/>
+      <xsl:apply-templates select="ancestor::*/*/legalnotice"
+                           mode="boost.footer"/>
+      <xsl:apply-templates select="ancestor::*/*/para[@role='copyright']"/>
+    </div>
   </xsl:template>
 
   <!-- We don't want refentry's to show up in the TOC because they


### PR DESCRIPTION
The footer template has code to generate revision number,
which was never updated to git and therefore generates no text,
but still generates a somewhat complex table structure. This
commit removes code for version numbers, and makes output a simple
div.

I've also added a hook to use pick content of whatever paragraph
with role of 'copyright' the document has, since right now we
pick copyright only from 'bookinfo' element, and Docbook renders
bookinfo element right at the start, and for Boost.Build documentation
I want documentation to start with some hints how to start, not
with a copyright statement.
