### PR TITLE
Change default image (online) location.

### DIFF
--- a/xsl/fo.xsl
+++ b/xsl/fo.xsl
@@ -512,9 +512,9 @@ General default options go here:
 <xsl:param name="admon.graphics">1</xsl:param>
 <xsl:param name="admon.graphics.extension">.svg</xsl:param>
 <xsl:param name="draft.mode">no</xsl:param>
-<xsl:param name="admon.graphics.path">http://svn.boost.org/svn/boost/trunk/doc/src/images/</xsl:param>
-<xsl:param name="callout.graphics.path">http://svn.boost.org/svn/boost/trunk/doc/src/images/callouts/</xsl:param>
-<xsl:param name="img.src.path">http://svn.boost.org/svn/boost/trunk/doc/html/</xsl:param>
+<xsl:param name="admon.graphics.path">http://www.boost.org/doc/libs/release/doc/src/images/</xsl:param>
+<xsl:param name="callout.graphics.path">http://www.boost.org/doc/libs/release/doc/src/images/callouts/</xsl:param>
+<xsl:param name="img.src.path">http://www.boost.org/doc/libs/release/doc/html/</xsl:param>
 
 </xsl:stylesheet>
 

--- a/xsl/fo.xsl
+++ b/xsl/fo.xsl
@@ -512,9 +512,9 @@ General default options go here:
 <xsl:param name="admon.graphics">1</xsl:param>
 <xsl:param name="admon.graphics.extension">.svg</xsl:param>
 <xsl:param name="draft.mode">no</xsl:param>
-<xsl:param name="admon.graphics.path">http://www.boost.org/doc/libs/release/doc/src/images/</xsl:param>
-<xsl:param name="callout.graphics.path">http://www.boost.org/doc/libs/release/doc/src/images/callouts/</xsl:param>
-<xsl:param name="img.src.path">http://www.boost.org/doc/libs/release/doc/html/</xsl:param>
+<xsl:param name="admon.graphics.path">http://www.boost.org/doc/libs/develop/doc/src/images/</xsl:param>
+<xsl:param name="callout.graphics.path">http://www.boost.org/doc/libs/develop/doc/src/images/callouts/</xsl:param>
+<xsl:param name="img.src.path">http://www.boost.org/doc/libs/devlop/doc/html/</xsl:param>
 
 </xsl:stylesheet>
 


### PR DESCRIPTION
I get HTTP 303 errors when retrieving images from the old location (browser is fine, but Java chokes while building the PDF's).  I couldn't find a git location that didn't also give 303 errors, so this seems to be the next best alternative.