### PR TITLE
Upgrade DOCBOOK_XSL_VERSION

### DIFF
--- a/setup_boostbook.py
+++ b/setup_boostbook.py
@@ -11,7 +11,7 @@
 
 # User configuration
 # (MAINTANERS: please, keep in synch with setup_boostbook.sh)
-DOCBOOK_XSL_VERSION = "1.75.2"
+DOCBOOK_XSL_VERSION = "1.79.1"
 DOCBOOK_DTD_VERSION = "4.2"
 FOP_VERSION = "0.94"
 FOP_JDK_VERSION="1.4"
@@ -27,8 +27,10 @@ import sys
 import optparse
 import shutil
 
+# sys.path.append( os.path.join( os.path.dirname( sys.modules[ __name__ ].__file__ )
+#                               , "../regression/xsl_reports/utils" ) )
 sys.path.append( os.path.join( os.path.dirname( sys.modules[ __name__ ].__file__ )
-                               , "../regression/xsl_reports/utils" ) )
+                               , "../regression/reports/src/utils" ) )
 
 import checked_system
 import urllib2
@@ -150,21 +152,21 @@ def adjust_user_config( config_file
 
 def setup_docbook_xsl( tools_directory ):
     print "DocBook XSLT Stylesheets ..."
-    DOCBOOK_XSL_TARBALL = os.path.join( tools_directory, "docbook-xsl-%s.tar.gz" % DOCBOOK_XSL_VERSION )
-    DOCBOOK_XSL_URL     = "%s/docbook-xsl/%s/%s/download" % (SOURCEFORGE_DOWNLOAD, DOCBOOK_XSL_VERSION, os.path.basename( DOCBOOK_XSL_TARBALL ) )
+    DOCBOOK_XSL_ZIP = os.path.join( tools_directory, "docbook-xsl-%s.zip" % DOCBOOK_XSL_VERSION )
+    DOCBOOK_XSL_URL     = "%s/docbook-xsl/%s/%s" % (SOURCEFORGE_DOWNLOAD, DOCBOOK_XSL_VERSION, os.path.basename( DOCBOOK_XSL_ZIP ) )
 
-    if os.path.exists( DOCBOOK_XSL_TARBALL ):
+    if os.path.exists( DOCBOOK_XSL_ZIP ):
         print "    Using existing DocBook XSLT Stylesheets (version %s)." % DOCBOOK_XSL_VERSION
     else:
         print "    Downloading DocBook XSLT Stylesheets version %s..." % DOCBOOK_XSL_VERSION
         print "        from %s" % DOCBOOK_XSL_URL
-        http_get( DOCBOOK_XSL_TARBALL, DOCBOOK_XSL_URL )
+        http_get( DOCBOOK_XSL_ZIP, DOCBOOK_XSL_URL )
 
     DOCBOOK_XSL_DIR = to_posix( os.path.join( tools_directory, "docbook-xsl-%s" % DOCBOOK_XSL_VERSION ) )
 
     if not os.path.exists( DOCBOOK_XSL_DIR ):
         print "    Expanding DocBook XSLT Stylesheets into %s..." % DOCBOOK_XSL_DIR
-        gunzip( DOCBOOK_XSL_TARBALL, tools_directory )
+        unzip( DOCBOOK_XSL_ZIP, tools_directory )
         print "    done."
 
     return DOCBOOK_XSL_DIR

--- a/setup_boostbook.sh
+++ b/setup_boostbook.sh
@@ -7,7 +7,7 @@
 
 # User configuration
 # (MAINTANERS: please, keep in synch with setup_boostbook.py)
-DOCBOOK_XSL_VERSION=1.75.2
+DOCBOOK_XSL_VERSION=1.79.1
 DOCBOOK_DTD_VERSION=4.2
 FOP_VERSION=0.94
 FOP_JDK_VERSION=1.4
@@ -19,9 +19,9 @@ HTTP_GET_CMD="curl -O -L"
 # No user configuration below this point-------------------------------------
 
 # Get the DocBook XSLT Stylesheets
-DOCBOOK_XSL_TARBALL=docbook-xsl-$DOCBOOK_XSL_VERSION.tar.gz
-DOCBOOK_XSL_URL=$SOURCEFORGE_DOWNLOAD/docbook-xsl/$DOCBOOK_XSL_VERSION/$DOCBOOK_XSL_TARBALL
-if test -f $DOCBOOK_XSL_TARBALL; then
+DOCBOOK_XSL_ZIP=docbook-xsl-$DOCBOOK_XSL_VERSION.zip
+DOCBOOK_XSL_URL=$SOURCEFORGE_DOWNLOAD/docbook-xsl/$DOCBOOK_XSL_VERSION/$DOCBOOK_XSL_ZIP
+if test -f $DOCBOOK_XSL_ZIP; then
   echo "Using existing DocBook XSLT Stylesheets (version $DOCBOOK_XSL_VERSION)."
 else
   echo "Downloading DocBook XSLT Stylesheets version $DOCBOOK_XSL_VERSION..."
@@ -31,7 +31,8 @@ fi
 DOCBOOK_XSL_DIR="$PWD/docbook-xsl-$DOCBOOK_XSL_VERSION"
 if test ! -d docbook-xsl-$DOCBOOK_XSL_VERSION; then
   echo -n "Expanding DocBook XSLT Stylesheets into $DOCBOOK_XSL_DIR..."
-  gunzip -cd $DOCBOOK_XSL_TARBALL | tar xf -
+  # gunzip -cd $DOCBOOK_XSL_TARBALL | tar xf -
+  unzip $DOCBOOK_XSL_ZIP
   echo "done."
 fi
 


### PR DESCRIPTION
Per a request, this updates DOCBOOK_XSL_VERSION from 1.75.2 to 1.79.1, and switches to the zip file download because the tar.gz archive isn't available.

As far as the general topic of installing the docs toolchain, these scripts at https://github.com/boostorg/release-tools/tree/develop/build_docs are able to install necessary apt, gem, and pip packages, and build docs for boost libraries.  So it's probably not necessary to extensively enhance `setup_boostbook.sh`, just use the `build_docs` scripts.
