### PR TITLE
Fix missing noexcept markup for destructors

### DIFF
--- a/xsl/doxygen/doxygen2boostbook.xsl
+++ b/xsl/doxygen/doxygen2boostbook.xsl
@@ -1351,6 +1351,7 @@
   <!-- Handle Destructors -->
   <xsl:template name="destructor">
     <destructor>
+      <xsl:call-template name="function.attributes"/>
       <xsl:call-template name="function.children"/>
     </destructor>
     <xsl:text>&#10;</xsl:text><!-- Newline -->


### PR DESCRIPTION
This fixes missing noexcept specifiers for destructors in a Doxygen-generated documentation.