### PR TITLE
Fix duplicate equal signs in Doxygen-generated enum value initializers

### DIFF
--- a/xsl/doxygen/doxygen2boostbook.xsl
+++ b/xsl/doxygen/doxygen2boostbook.xsl
@@ -324,7 +324,8 @@
 
           <xsl:if test="initializer">
             <default>
-              <xsl:apply-templates select="initializer/*|initializer/text()" mode="passthrough"/>
+              <xsl:apply-templates select="initializer/*|initializer/text()"
+                mode="enumvalue.initializer"/>
             </default>
           </xsl:if>
 
@@ -334,6 +335,24 @@
         </enumvalue>
       </xsl:otherwise>
     </xsl:choose>
+  </xsl:template>
+
+  <xsl:template match="text()" mode="enumvalue.initializer">
+    <!-- Remove the leading '=' sign from enum value initializers, the '='
+         character will be added later, by the templates processing <default>
+         tags. -->
+    <xsl:choose>
+      <xsl:when test="starts-with(normalize-space(string(.)), '=')">
+        <xsl:value-of select="normalize-space(substring-after(string(.), '='))"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:copy-of select="."/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template match="*" mode="enumvalue.initializer">
+    <xsl:apply-templates mode="passthrough"/>
   </xsl:template>
 
   <xsl:template name="doxygen.include.header.rec">


### PR DESCRIPTION
Doxygen 1.9.1 generates enum `<initializer>` tags with text starting with an equal sign ('=') followed by the enum value initializer. This sign was copied under the BoostBook `<default>` tag, and BoostBook styleseets add an equal sign of their own when converting this tag to HTML. This resulted in duplicate equal signs in the HTML output.

This commit strips the leading equal sign from the initializer before putting it into the `<default>` tag.

Before:

![Screenshot_20240428_143057](https://github.com/boostorg/boostbook/assets/1589747/396625a1-23ee-48bd-9a1f-0dd316fab5bc)

After:

![Screenshot_20240428_151556](https://github.com/boostorg/boostbook/assets/1589747/f5e29856-5328-4b4f-8ce5-988189e22a42)
