### PR TITLE
Fix missing members and functions in named groups in Doxygen output

### DIFF
--- a/dtd/boostbook.dtd
+++ b/dtd/boostbook.dtd
@@ -240,7 +240,7 @@
 <!ELEMENT postconditions ANY>
 <!ATTLIST postconditions %boost.common.attrib;>
 
-<!ELEMENT method-group (method|overloaded-method)*>
+<!ELEMENT method-group (constructor|copy-assignment|destructor|method|overloaded-method)*>
 <!ATTLIST method-group
     name  CDATA  #REQUIRED
     %boost.common.attrib;>

--- a/xsl/doxygen/doxygen2boostbook.xsl
+++ b/xsl/doxygen/doxygen2boostbook.xsl
@@ -788,7 +788,6 @@
             </xsl:apply-templates>
           </method-group>
           <xsl:text>&#10;</xsl:text><!-- Newline -->
-          <xsl:apply-templates/>
         </xsl:if>
       </xsl:when>
       <xsl:when test="@kind='protected-func'">
@@ -800,7 +799,6 @@
           </xsl:apply-templates>
         </method-group>
         <xsl:text>&#10;</xsl:text><!-- Newline -->
-        <xsl:apply-templates/>
       </xsl:when>
       <xsl:when test="@kind='private-func'">
         <xsl:variable name="members" select="./memberdef"/>
@@ -819,7 +817,6 @@
           </method-group>
           <xsl:text>&#10;</xsl:text><!-- Newline -->
         </xsl:if>
-        <xsl:apply-templates/>
       </xsl:when>
       <xsl:when test="@kind='friend'">
         <xsl:if test="./memberdef/detaileddescription/para or ./memberdef/briefdescription/para">
@@ -870,9 +867,37 @@
         </xsl:apply-templates>
       </xsl:when>
       <xsl:when test="@kind='user-defined'">
-        <xsl:apply-templates>
-          <xsl:with-param name="in-file" select="$in-file"/>
-        </xsl:apply-templates>
+        <xsl:choose>
+          <xsl:when test="not(string(./header/text()) = '')">
+            <xsl:variable name="group-type">
+              <xsl:choose>
+                <xsl:when test="ancestor::compounddef/attribute::kind='namespace'">
+                  <xsl:value-of select="'free-function-group'"/>
+                </xsl:when>
+                <xsl:otherwise>
+                  <xsl:value-of select="'method-group'"/>
+                </xsl:otherwise>
+              </xsl:choose>
+            </xsl:variable>
+            <xsl:element name="{$group-type}">
+              <xsl:attribute name="name">
+                <xsl:value-of select="string(./header/text())"/>
+              </xsl:attribute>
+              <xsl:text>&#10;</xsl:text><!-- Newline -->
+              <xsl:apply-templates>
+                <xsl:with-param name="in-section" select="true()"/>
+                <xsl:with-param name="in-file" select="$in-file"/>
+              </xsl:apply-templates>
+            </xsl:element>
+            <xsl:text>&#10;</xsl:text><!-- Newline -->
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:apply-templates>
+              <xsl:with-param name="in-section" select="true()"/>
+              <xsl:with-param name="in-file" select="$in-file"/>
+            </xsl:apply-templates>
+          </xsl:otherwise>
+        </xsl:choose>
       </xsl:when>
       <xsl:when test="@kind=''">
         <xsl:apply-templates select="memberdef[generate-id() =
@@ -937,19 +962,13 @@
             
             <xsl:choose>
               <xsl:when test="string(name/text())=$in-class">
-                <xsl:if test="not ($in-section)">
-                  <xsl:call-template name="constructor"/>
-                </xsl:if>
+                <xsl:call-template name="constructor"/>
               </xsl:when>
               <xsl:when test="string(name/text())=concat('~',$in-class)">
-                <xsl:if test="not ($in-section)">
-                  <xsl:call-template name="destructor"/>
-                </xsl:if>
+                <xsl:call-template name="destructor"/>
               </xsl:when>
               <xsl:when test="string(name/text())='operator='">
-                <xsl:if test="not ($in-section)">
-                  <xsl:call-template name="copy-assignment"/>
-                </xsl:if>
+                <xsl:call-template name="copy-assignment"/>
               </xsl:when>
               <xsl:when test="normalize-space(string(type))=''
                               and contains(name/text(), 'operator ')">

--- a/xsl/function.xsl
+++ b/xsl/function.xsl
@@ -1133,7 +1133,7 @@
           </xsl:call-template>
         </xsl:with-param>
       </xsl:call-template>
-      <xsl:apply-templates select="method|overloaded-method"
+      <xsl:apply-templates select="constructor|copy-assignment|destructor|method|overloaded-method"
         mode="synopsis">
         <xsl:with-param name="indentation" select="$indentation"/>
       </xsl:apply-templates>
@@ -1161,7 +1161,7 @@
         </xsl:with-param>
         <xsl:with-param name="text">
           <orderedlist>
-            <xsl:apply-templates select="method|overloaded-method"
+            <xsl:apply-templates select="constructor|copy-assignment|destructor|method|overloaded-method"
               mode="reference"/>
           </orderedlist>
         </xsl:with-param>


### PR DESCRIPTION
Previously, class members and free functions in `sectiondef` with `kind="user-defined"` would be stripped from HTML output, making function grouping effectively non-functional. This commit fixes this by converting such `sectiondef`s to either `method-group` or `free-function-group` in BoostBook output, depending on whether the grouping is within a class or namespace.

Additionally, previously constructors, destructors and assignment operators were not allowed to be inside `method-group`s, which were another reason for these members to be stripped from the output. This commit allows these members in `member-group`s and modifies DTD accordingly.

Before:
![Screenshot_20240504_131801](https://github.com/boostorg/boostbook/assets/1589747/33685f45-2d84-4413-aad0-da5e64e2f4b5)

After:
![Screenshot_20240504_154004](https://github.com/boostorg/boostbook/assets/1589747/2a412442-4e74-489e-a464-f0dea25da79b)
![Screenshot_20240504_154042](https://github.com/boostorg/boostbook/assets/1589747/d977032b-dc45-4b8d-9166-ab9021809e65)

An example where this will likely fix missing documentation:

https://www.boost.org/doc/libs/1_85_0/libs/test/doc/html/boost/unit_test/progress_monitor_t.html

vs.

https://github.com/boostorg/test/blob/822dc24718a33316bcef78b08f6bf57ae20d9335/include/boost/test/progress_monitor.hpp#L35-L49

Notice that the methods enclosed in `@{`/`@}` tags are completely missing from the documentation.