### PR TITLE
Support disabling sorting function and template parameters

### DIFF
--- a/xsl/function.xsl
+++ b/xsl/function.xsl
@@ -24,6 +24,10 @@
        unless everything fits on a single line. -->
   <xsl:param name="boost.short.result.type">12</xsl:param>
 
+  <!-- When true, the stylesheet will sort parameters of functions and
+       templates alphabetically in detailed description. -->
+  <xsl:param name="boost.sort.params">1</xsl:param>
+
   <!-- Display a function declaration -->
   <xsl:template name="function">
     <xsl:param name="indentation"/>
@@ -822,7 +826,7 @@
                   list-presentation="table"
                 </xsl:processing-instruction>
                 <xsl:for-each select="parameter|signature/parameter">
-		              <xsl:sort select="attribute::name"/>
+                  <xsl:sort select="attribute::name[$boost.sort.params!=0]"/>
                   <xsl:if test="description">
                     <varlistentry>
                       <term>
@@ -853,7 +857,7 @@
                 </xsl:processing-instruction>
                 <xsl:for-each select="template/template-type-parameter|
                       template/template-nontype-parameter">
-                  <xsl:sort select="attribute::name"/>
+                  <xsl:sort select="attribute::name[$boost.sort.params!=0]"/>
                   <xsl:if test="purpose">
                     <varlistentry>
                       <term>


### PR DESCRIPTION
This commit adds a new XSL parameter `boost.sort.params`, which allows users to disable alphabetical sorting of the function and template parameters in detailed descriptions of functions and classes. By default, sorting is enabled, which maintains the previous behavior.

Sorting is disabled when the parameter is set to 0. In this case, parameters are listed in the order they are listed in the BoostBook documentation, which is normally the same as they are listed in the function signature or template preamble.

Before (or after, with `boost.sort.params` set to 1 or default):
![Screenshot_20240513_034014](https://github.com/boostorg/boostbook/assets/1589747/4198da56-7a26-4749-a173-704840c27280)

After, with `boost.sort.params=0`:
![Screenshot_20240513_034102](https://github.com/boostorg/boostbook/assets/1589747/15a90bb3-6ca7-4bc3-8e98-631d69609a91)
